### PR TITLE
fixes #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ ENV container docker
 
 RUN yum -y update; yum clean all
 
+RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+
 RUN systemctl mask dev-mqueue.mount dev-hugepages.mount \
     systemd-remount-fs.service sys-kernel-config.mount \
     sys-kernel-debug.mount sys-fs-fuse-connections.mount
-RUN systemctl mask display-manager.service 
+RUN systemctl mask display-manager.service systemd-logind.service
 RUN systemctl disable graphical.target; systemctl enable multi-user.target
 
 ADD dbus.service /etc/systemd/system/dbus.service
@@ -18,5 +20,6 @@ RUN echo "UseDNS no" >> /etc/ssh/sshd_config
 RUN sed -i 's/UsePrivilegeSeparation sandbox/UsePrivilegeSeparation no/' /etc/ssh/sshd_config
 
 VOLUME ["/sys/fs/cgroup"]
+VOLUME ["/run"]
 
 CMD  ["/usr/lib/systemd/systemd"]

--- a/run-interactive.sh
+++ b/run-interactive.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo docker run --rm -t -i -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /tmp/$(mktemp -d):/run maci/systemd /usr/lib/systemd/systemd
+sudo docker run --rm -t -i -v /sys/fs/cgroup:/sys/fs/cgroup:ro maci/systemd /usr/lib/systemd/systemd

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sudo docker run -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /tmp/$(mktemp -d):/run maci/systemd /usr/lib/systemd/systemd
+sudo docker run -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro maci/systemd /usr/lib/systemd/systemd
 


### PR DESCRIPTION
- swap fakesystemd with systemd
- mask systemd-login
- make `/run` a volume (so mounting it is not required at `docker run`)
